### PR TITLE
Fix broken footer

### DIFF
--- a/_includes/post-list.html
+++ b/_includes/post-list.html
@@ -7,7 +7,7 @@
 
             <h2><a href="{{ site.baseurl }}{{ page.url }}">{{ page.title }}</a></h2>
             {% include post-meta.html %}
-            {{ page.excerpt | markdownify | truncatewords: 60 }}
+            {{ page.excerpt | truncatewords: 60 | markdownify}}
 
           </article>
         </li>
@@ -24,7 +24,7 @@
 
             <h2><a href="{{ site.baseurl }}{{ page.url }}">{{ page.title }}</a></h2>
             {% include post-meta.html %}
-            {{ page.excerpt | markdownify | truncatewords: 60 }}
+            {{ page.excerpt | truncatewords: 60 | markdownify}}
 
           </article>
         </li>


### PR DESCRIPTION
fix: reverse markdownify and truncatewords, because HTML tags were truncated, resulting in a broken footer